### PR TITLE
Compatibility with Thunderbird 128

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,12 +3,12 @@
     "name": "Just Report It",
     "description": "The proper way to report spam!",
     "default_locale": "en-US",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "author": "Nicolas Provencher",
     "browser_specific_settings": {
         "gecko": {
             "id": "admin@justreport.it",
-            "strict_min_version": "115.0"
+            "strict_min_version": "128.0"
         }
     },
     "background": {
@@ -33,6 +33,7 @@
         "messagesMove",
         "messagesRead",
         "messagesDelete",
+        "messagesUpdate",
         "accountsRead",
         "accountsFolders",
         "storage",


### PR DESCRIPTION
Thunderbird 128 introduced a rare backward incompatibility in its WebExtension API: The method `messages.update()` is now protected by the `messagesUpdate` permission.